### PR TITLE
Add Pixeltools to GUI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - [FrameShift](https://gaurox.dev/frameshift/) - Windows GUI for FFmpeg with Explorer integration for converting, compressing, trimming, and processing media files.
 - [HandBrake](https://handbrake.fr/) - A popular open-source video transcoder with FFmpeg as its core engine.
 - [LosslessCut](https://github.com/mifi/lossless-cut) - A simple, cross-platform tool for lossless trimming and cutting of video and audio files using FFmpeg.
+- [Pixeltools](https://pixeltools.io/convert-video) - A free, browser-based FFmpeg GUI for converting, compressing, and trimming video and audio, with no install or signup required.
 - [Shotcut](https://shotcut.org/) - A free, open-source, cross-platform video editor that uses FFmpeg for video processing.
 
 ## Plugins and Extensions


### PR DESCRIPTION
Free, browser-based FFmpeg GUI (built on ffmpeg.wasm) for converting, compressing, and trimming video and audio, no install or signup required. The GUI Tools section is currently all desktop apps (Avidemux, HandBrake, Shotcut, etc.) with no browser-based option.

## Thank you for your contribution!

Please make sure your pull request follows our guidelines:

### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows our quality and content standards.
- [x] I have not added a link to my own project if it's not notable or widely 

### Description of the Change

Pixeltools.io is a free, browser-based file conversion suite I maintain. It runs FFmpeg via ffmpeg.wasm entirely client-side, so no files are uploaded and no signup is needed. The GUI Tools section currently lists six tools, all desktop installs (Avidemux, FFmpeg Batch AV Converter, FrameShift, HandBrake, LosslessCut, Shotcut) — Pixeltools adds the only browser-based option, filling that gap rather than duplicating an existing entry.

### Additional Notes (if any)

Disclosure: I'm the maintainer of pixeltools.io. Added it alphabetically between LosslessCut and Shotcut to match the section's existing order. Happy to adjust wording or placement if it doesn't fit.